### PR TITLE
fix seed mvrnorm

### DIFF
--- a/R/mvrnorm.R
+++ b/R/mvrnorm.R
@@ -23,7 +23,7 @@ mvrnorm <-
     eS <- eigen(Sigma, symmetric = TRUE)
     ev <- eS$values
     if(!all(ev >= -tol*abs(ev[1L]))) stop("'Sigma' is not positive definite")
-    X <- matrix(rnorm(p * n), n)
+    X <- matrix(rnorm(p * n), n, byrow = TRUE)
     if(empirical) {
         X <- scale(X, TRUE, FALSE) # remove means
         X <- X %*% svd(X, nu = 0)$v # rotate to PCs


### PR DESCRIPTION
The fix will generate now the same two initial draws

```
set.seed(345234)
mvrnorm(2,c(0,0),matrix(c(1,0,0,1),2,2))

set.seed(345234)
mvrnorm(10,c(0,0),matrix(c(1,0,0,1),2,2))
```

similarly to 

```
set.seed(345234)
rnorm(2)

set.seed(345234)
rnorm(10)
```
