### PR TITLE
Issue in glm.nb() (MASS) – Non-convergence due to theta.ml behaviour for Poisson-like data 

### DIFF
--- a/R/negbin.R
+++ b/R/negbin.R
@@ -9,7 +9,7 @@ anova.negbin <- function(object, ..., test = "Chisq")
     object$call[[1L]] <- quote(stats::glm)
     if(is.null(object$link)) object$link <- as.name("log")
     object$call$family <-
-        call("negative.binomial", theta = object$ theta, link = object$link)
+      call("negative.binomial", theta = object$ theta, link = object$link)
     NextMethod(object, test = test)
   } else {
     if(test != "Chisq")
@@ -45,153 +45,264 @@ anova.negbin <- function(object, ..., test = "Chisq")
 
 print.Anova <- function(x, ...)
 {
-    heading <- attr(x, "heading")
-    if(!is.null(heading)) cat(heading, sep = "\n")
-    attr(x, "heading") <- NULL
-    res <- format.data.frame(x, ...)
-    nas <- is.na(x) # format loses this
-    res[] <- sapply(seq_len(ncol(res)), function(i){
-        x <- as.character(res[[i]])
-        x[nas[, i]] <- ""
-        x
-    })
-    print.data.frame(res)
-    invisible(x)
+  heading <- attr(x, "heading")
+  if(!is.null(heading)) cat(heading, sep = "\n")
+  attr(x, "heading") <- NULL
+  res <- format.data.frame(x, ...)
+  nas <- is.na(x) # format loses this
+  res[] <- sapply(seq_len(ncol(res)), function(i){
+    x <- as.character(res[[i]])
+    x[nas[, i]] <- ""
+    x
+  })
+  print.data.frame(res)
+  invisible(x)
 }
 
 family.negbin <- function(object, ...) object$family
 
 glm.convert <- function(object)
 {
-    object$call[[1L]] <- quote(stats::glm)
-    if(is.null(object$link))
-        object$link <- as.name("log")
-    object$call$family <- call("negative.binomial", theta = object$theta,
-                               link = object$link)
-    object$call$init.theta <- object$call$link <- NULL
-    class(object) <- c("glm", "lm")
-    object
+  object$call[[1L]] <- quote(stats::glm)
+  if(is.null(object$link))
+    object$link <- as.name("log")
+  object$call$family <- call("negative.binomial", theta = object$theta,
+                             link = object$link)
+  object$call$init.theta <- object$call$link <- NULL
+  class(object) <- c("glm", "lm")
+  object
 }
 
 glm.nb <- function(formula, data, weights,
-		   subset, na.action, start = NULL, etastart, mustart,
-		   control = glm.control(...), method = "glm.fit",
-		   model = TRUE, x = FALSE, y = TRUE, contrasts = NULL, ...,
-		   init.theta, link = log)
+                   subset, na.action, start = NULL, etastart, mustart,
+                   control = glm.control(...), method = "glm.fit",
+                   model = TRUE, x = FALSE, y = TRUE, contrasts = NULL, ...,
+                   init.theta, link = log)
 {
-    loglik <- function(n, th, mu, y, w)
-        sum(w*(lgamma(th + y) - lgamma(th) - lgamma(y + 1) + th * log(th) +
-               y * log(mu + (y == 0)) - (th + y) * log(th + mu)))
-
-    link <- substitute(link)
-    fam0 <- if(missing(init.theta))
-        do.call("poisson", list(link = link))
-    else
-        do.call("negative.binomial", list(theta = init.theta, link = link))
-
-    mf <- Call <- match.call()
-    m <- match(c("formula", "data", "subset", "weights", "na.action",
-        "etastart", "mustart", "offset"), names(mf), 0)
-    mf <- mf[c(1, m)]
-    mf$drop.unused.levels <- TRUE
-    mf[[1L]] <- quote(stats::model.frame)
-    mf <- eval.parent(mf)
-    Terms <- attr(mf, "terms")
-    if(method == "model.frame") return(mf)
-    Y <- model.response(mf, "numeric")
-    ## null model support
-    X <- if (!is.empty.model(Terms)) model.matrix(Terms, mf, contrasts) else matrix(,NROW(Y),0)
-    w <- model.weights(mf)
-    if(!length(w)) w <- rep(1, nrow(mf))
-    else if(any(w < 0)) stop("negative weights not allowed")
-    offset <- model.offset(mf)
-    ## these allow starting values to be expressed in terms of other vars.
-    mustart <- model.extract(mf, "mustart")
-    etastart <- model.extract(mf, "etastart")
-    n <- length(Y)
-    if(!missing(method)) {
-        if(!exists(method, mode = "function"))
-            stop(gettextf("unimplemented method: %s", sQuote(method)),
-                 domain = NA)
-        glm.fitter <- get(method)
-    } else {
-        method <- "glm.fit"
-        glm.fitter <- stats::glm.fit
-    }
-    if(control$trace > 1) message("Initial fit:")
-    fit <- glm.fitter(x = X, y = Y, weights = w, start = start,
-                      etastart = etastart, mustart = mustart,
-                      offset = offset, family = fam0,
-                      control = list(maxit=control$maxit,
-                      epsilon = control$epsilon,
-                      trace = control$trace > 1),
-                      intercept = attr(Terms, "intercept") > 0)
-    class(fit) <- c("glm", "lm")
-    mu <- fit$fitted.values
-    th <- as.vector(theta.ml(Y, mu, sum(w), w, limit = control$maxit, trace =
+  loglik <- function(n, th, mu, y, w)
+    sum(w*(lgamma(th + y) - lgamma(th) - lgamma(y + 1) + th * log(th) +
+             y * log(mu + (y == 0)) - (th + y) * log(th + mu)))
+  
+  link <- substitute(link)
+  fam0 <- if(missing(init.theta))
+    do.call("poisson", list(link = link))
+  else
+    do.call("negative.binomial", list(theta = init.theta, link = link))
+  
+  mf <- Call <- match.call()
+  m <- match(c("formula", "data", "subset", "weights", "na.action",
+               "etastart", "mustart", "offset"), names(mf), 0)
+  mf <- mf[c(1, m)]
+  mf$drop.unused.levels <- TRUE
+  mf[[1L]] <- quote(stats::model.frame)
+  mf <- eval.parent(mf)
+  Terms <- attr(mf, "terms")
+  if(method == "model.frame") return(mf)
+  Y <- model.response(mf, "numeric")
+  ## null model support
+  X <- if (!is.empty.model(Terms)) model.matrix(Terms, mf, contrasts) else matrix(,NROW(Y),0)
+  w <- model.weights(mf)
+  if(!length(w)) w <- rep(1, nrow(mf))
+  else if(any(w < 0)) stop("negative weights not allowed")
+  offset <- model.offset(mf)
+  ## these allow starting values to be expressed in terms of other vars.
+  mustart <- model.extract(mf, "mustart")
+  etastart <- model.extract(mf, "etastart")
+  n <- length(Y)
+  if(!missing(method)) {
+    if(!exists(method, mode = "function"))
+      stop(gettextf("unimplemented method: %s", sQuote(method)),
+           domain = NA)
+    glm.fitter <- get(method)
+  } else {
+    method <- "glm.fit"
+    glm.fitter <- stats::glm.fit
+  }
+  if(control$trace > 1) message("Initial fit:")
+  fit <- glm.fitter(x = X, y = Y, weights = w, start = start,
+                    etastart = etastart, mustart = mustart,
+                    offset = offset, family = fam0,
+                    control = list(maxit=control$maxit,
+                                   epsilon = control$epsilon,
+                                   trace = control$trace > 1),
+                    intercept = attr(Terms, "intercept") > 0)
+  class(fit) <- c("glm", "lm")
+  mu <- fit$fitted.values
+  th <- as.vector(theta.ml(Y, mu, sum(w), w, limit = control$maxit, trace =
                              control$trace> 2)) # drop attributes
-    if(control$trace > 1)
-        message(gettextf("Initial value for 'theta': %f", signif(th)),
-                domain = NA)
+  if(control$trace > 1)
+    message(gettextf("Initial value for 'theta': %f", signif(th)),
+            domain = NA)
+  fam <- do.call("negative.binomial", list(theta = th, link = link))
+  iter <- 0
+  d1 <- sqrt(2 * max(1, fit$df.residual))
+  d2 <- del <- 1
+  g <- fam$linkfun
+  Lm <- loglik(n, th, mu, Y, w)
+  Lm0 <- Lm + 2 * d1
+  while((iter <- iter + 1) <= control$maxit &&
+        (abs(Lm0 - Lm)/d1 + abs(del)/d2) > control$epsilon) {
+    eta <- g(mu)
+    fit <- glm.fitter(x = X, y = Y, weights = w, etastart =
+                        eta, offset = offset, family = fam,
+                      control = list(maxit=control$maxit,
+                                     epsilon = control$epsilon,
+                                     trace = control$trace > 1),
+                      intercept = attr(Terms, "intercept") > 0)
+    t0 <- th
+    th <- theta.ml(Y, mu, sum(w), w, limit=control$maxit,
+                   trace = control$trace > 2)
     fam <- do.call("negative.binomial", list(theta = th, link = link))
-    iter <- 0
-    d1 <- sqrt(2 * max(1, fit$df.residual))
-    d2 <- del <- 1
-    g <- fam$linkfun
+    mu <- fit$fitted.values
+    del <- t0 - th
+    Lm0 <- Lm
     Lm <- loglik(n, th, mu, Y, w)
-    Lm0 <- Lm + 2 * d1
-    while((iter <- iter + 1) <= control$maxit &&
-          (abs(Lm0 - Lm)/d1 + abs(del)/d2) > control$epsilon) {
-        eta <- g(mu)
-        fit <- glm.fitter(x = X, y = Y, weights = w, etastart =
-                          eta, offset = offset, family = fam,
-                          control = list(maxit=control$maxit,
-                          epsilon = control$epsilon,
-                          trace = control$trace > 1),
-                          intercept = attr(Terms, "intercept") > 0)
-        t0 <- th
-        th <- theta.ml(Y, mu, sum(w), w, limit=control$maxit,
-                       trace = control$trace > 2)
-        fam <- do.call("negative.binomial", list(theta = th, link = link))
-        mu <- fit$fitted.values
-        del <- t0 - th
-        Lm0 <- Lm
-        Lm <- loglik(n, th, mu, Y, w)
-        if(control$trace) {
-            Ls <- loglik(n, th, Y, Y, w)
-            Dev <- 2 * (Ls - Lm)
-            message(sprintf("Theta(%d) = %f, 2(Ls - Lm) = %f",
-                            iter, signif(th), signif(Dev)), domain = NA)
-        }
+    if(control$trace) {
+      Ls <- loglik(n, th, Y, Y, w)
+      Dev <- 2 * (Ls - Lm)
+      message(sprintf("Theta(%d) = %f, 2(Ls - Lm) = %f",
+                      iter, signif(th), signif(Dev)), domain = NA)
     }
-    if(!is.null(attr(th, "warn"))) fit$th.warn <- attr(th, "warn")
-    if(iter > control$maxit) {
-        warning("alternation limit reached")
-        fit$th.warn <- gettext("alternation limit reached")
-    }
-
+  }
+  if(!is.null(attr(th, "warn"))) fit$th.warn <- attr(th, "warn")
+  if(iter > control$maxit) {
+    warning("alternation limit reached")
+    fit$th.warn <- gettext("alternation limit reached")
+  }
+  
   # If an offset and intercept are present, iterations are needed to
   # compute the Null deviance; these are done here, unless the model
   # is NULL, in which case the computations have been done already
   #
+  if(length(offset) && attr(Terms, "intercept")) {
+    null.deviance <-
+      if(length(Terms))
+        glm.fitter(X[, "(Intercept)", drop = FALSE], Y, w,
+                   offset = offset, family = fam,
+                   control = list(maxit=control$maxit,
+                                  epsilon = control$epsilon,
+                                  trace = control$trace > 1),
+                   intercept = TRUE
+        )$deviance
+    else fit$deviance
+    fit$null.deviance <- null.deviance
+  }
+  class(fit) <- c("negbin", "glm", "lm")
+  fit$terms <- Terms
+  fit$formula <- as.vector(attr(Terms, "formula"))
+  ## make result somewhat reproducible
+  Call$init.theta <- signif(as.vector(th), 10)
+  Call$link <- link
+  fit$call <- Call
+  if(model) fit$model <- mf
+  fit$na.action <- attr(mf, "na.action")
+  if(x) fit$x <- X
+  if(!y) fit$y <- NULL
+  fit$theta <- as.vector(th)
+  fit$SE.theta <- attr(th, "SE")
+  fit$twologlik <- as.vector(2 * Lm)
+  fit$aic <- -fit$twologlik + 2*fit$rank + 2
+  fit$contrasts <- attr(X, "contrasts")
+  fit$xlevels <- .getXlevels(Terms, mf)
+  fit$method <- method
+  fit$control <- control
+  fit$offset <- offset
+  fit
+}
+
+
+## Newly added function. corrected glm.nb for the cases
+## where data behaves like poisson and theta grows to infinity
+## it applies poisson fallback based on theta.ml2
+glm.nb2 <- function(formula, data, weights,
+                   subset, na.action, start = NULL, etastart, mustart,
+                   control = glm.control(...), method = "glm.fit",
+                   model = TRUE, x = FALSE, y = TRUE, contrasts = NULL, ...,
+                   init.theta, link = log)
+{
+  loglik <- function(n, th, mu, y, w)
+    sum(w*(lgamma(th + y) - lgamma(th) - lgamma(y + 1) + th * log(th) +
+             y * log(mu + (y == 0)) - (th + y) * log(th + mu)))
+  
+  link <- substitute(link)
+  fam0 <- if(missing(init.theta))
+    do.call("poisson", list(link = link))
+  else
+    do.call("negative.binomial", list(theta = init.theta, link = link))
+  
+  mf <- Call <- match.call()
+  m <- match(c("formula", "data", "subset", "weights", "na.action",
+               "etastart", "mustart", "offset"), names(mf), 0)
+  mf <- mf[c(1, m)]
+  mf$drop.unused.levels <- TRUE
+  mf[[1L]] <- quote(stats::model.frame)
+  mf <- eval.parent(mf)
+  Terms <- attr(mf, "terms")
+  if(method == "model.frame") return(mf)
+  Y <- model.response(mf, "numeric")
+  ## null model support
+  X <- if (!is.empty.model(Terms)) model.matrix(Terms, mf, contrasts) else matrix(,NROW(Y),0)
+  w <- model.weights(mf)
+  if(!length(w)) w <- rep(1, nrow(mf))
+  else if(any(w < 0)) stop("negative weights not allowed")
+  offset <- model.offset(mf)
+  ## these allow starting values to be expressed in terms of other vars.
+  mustart <- model.extract(mf, "mustart")
+  etastart <- model.extract(mf, "etastart")
+  n <- length(Y)
+  if(!missing(method)) {
+    if(!exists(method, mode = "function"))
+      stop(gettextf("unimplemented method: %s", sQuote(method)),
+           domain = NA)
+    glm.fitter <- get(method)
+  } else {
+    method <- "glm.fit"
+    glm.fitter <- stats::glm.fit
+  }
+  if(control$trace > 1) message("Initial fit:")
+  fit <- glm.fitter(x = X, y = Y, weights = w, start = start,
+                    etastart = etastart, mustart = mustart,
+                    offset = offset, family = fam0,
+                    control = list(maxit=control$maxit,
+                                   epsilon = control$epsilon,
+                                   trace = control$trace > 1),
+                    intercept = attr(Terms, "intercept") > 0)
+  class(fit) <- c("glm", "lm")
+  mu <- fit$fitted.values
+  th <- as.vector(theta.ml2(Y, mu, sum(w), w, limit = control$maxit, trace =
+                             control$trace> 2)) # drop attributes
+  
+  if(is.na(th)){
+    
+    fit <- glm.fitter(x = X, y = Y, weights = w, start = start,
+                      etastart = etastart, mustart = mustart,
+                      offset = offset, family = poisson(link = "log"),
+                      control = list(maxit=control$maxit,
+                                     epsilon = control$epsilon,
+                                     trace = control$trace > 1),
+                      intercept = attr(Terms, "intercept") > 0)
+    class(fit) <- c("glm", "lm")
+    mu <- fit$fitted.values
+    Lm <- sum(w*stats::dpois(Y,lambda = mu,log = TRUE))
+    
+    
     if(length(offset) && attr(Terms, "intercept")) {
-        null.deviance <-
-            if(length(Terms))
-                glm.fitter(X[, "(Intercept)", drop = FALSE], Y, w,
-                           offset = offset, family = fam,
-                           control = list(maxit=control$maxit,
-                           epsilon = control$epsilon,
-                           trace = control$trace > 1),
-                           intercept = TRUE
-                           )$deviance
-           else fit$deviance
-        fit$null.deviance <- null.deviance
+      null.deviance <-
+        if(length(Terms))
+          glm.fitter(X[, "(Intercept)", drop = FALSE], Y, w,
+                     offset = offset, family = poisson(link = "log"),
+                     control = list(maxit=control$maxit,
+                                    epsilon = control$epsilon,
+                                    trace = control$trace > 1),
+                     intercept = TRUE
+          )$deviance
+      else fit$deviance
+      fit$null.deviance <- null.deviance
     }
-    class(fit) <- c("negbin", "glm", "lm")
+
     fit$terms <- Terms
     fit$formula <- as.vector(attr(Terms, "formula"))
     ## make result somewhat reproducible
-    Call$init.theta <- signif(as.vector(th), 10)
     Call$link <- link
     fit$call <- Call
     if(model) fit$model <- mf
@@ -207,55 +318,137 @@ glm.nb <- function(formula, data, weights,
     fit$method <- method
     fit$control <- control
     fit$offset <- offset
-    fit
+    
+    return(fit)
+    
+  }
+  
+  if(control$trace > 1)
+    message(gettextf("Initial value for 'theta': %f", signif(th)),
+            domain = NA)
+  fam <- do.call("negative.binomial", list(theta = th, link = link))
+  iter <- 0
+  d1 <- sqrt(2 * max(1, fit$df.residual))
+  d2 <- del <- 1
+  g <- fam$linkfun
+  Lm <- loglik(n, th, mu, Y, w)
+  Lm0 <- Lm + 2 * d1
+  while((iter <- iter + 1) <= control$maxit &&
+        (abs(Lm0 - Lm)/d1 + abs(del)/d2) > control$epsilon) {
+    eta <- g(mu)
+    fit <- glm.fitter(x = X, y = Y, weights = w, etastart =
+                        eta, offset = offset, family = fam,
+                      control = list(maxit=control$maxit,
+                                     epsilon = control$epsilon,
+                                     trace = control$trace > 1),
+                      intercept = attr(Terms, "intercept") > 0)
+    t0 <- th
+    th <- theta.ml2(Y, mu, sum(w), w, limit=control$maxit,
+                   trace = control$trace > 2)
+    fam <- do.call("negative.binomial", list(theta = th, link = link))
+    mu <- fit$fitted.values
+    del <- t0 - th
+    Lm0 <- Lm
+    Lm <- loglik(n, th, mu, Y, w)
+    if(control$trace) {
+      Ls <- loglik(n, th, Y, Y, w)
+      Dev <- 2 * (Ls - Lm)
+      message(sprintf("Theta(%d) = %f, 2(Ls - Lm) = %f",
+                      iter, signif(th), signif(Dev)), domain = NA)
+    }
+  }
+  if(!is.null(attr(th, "warn"))) fit$th.warn <- attr(th, "warn")
+  if(iter > control$maxit) {
+    warning("alternation limit reached")
+    fit$th.warn <- gettext("alternation limit reached")
+  }
+  
+  # If an offset and intercept are present, iterations are needed to
+  # compute the Null deviance; these are done here, unless the model
+  # is NULL, in which case the computations have been done already
+  #
+  if(length(offset) && attr(Terms, "intercept")) {
+    null.deviance <-
+      if(length(Terms))
+        glm.fitter(X[, "(Intercept)", drop = FALSE], Y, w,
+                   offset = offset, family = fam,
+                   control = list(maxit=control$maxit,
+                                  epsilon = control$epsilon,
+                                  trace = control$trace > 1),
+                   intercept = TRUE
+        )$deviance
+    else fit$deviance
+    fit$null.deviance <- null.deviance
+  }
+  class(fit) <- c("negbin", "glm", "lm")
+  fit$terms <- Terms
+  fit$formula <- as.vector(attr(Terms, "formula"))
+  ## make result somewhat reproducible
+  Call$init.theta <- signif(as.vector(th), 10)
+  Call$link <- link
+  fit$call <- Call
+  if(model) fit$model <- mf
+  fit$na.action <- attr(mf, "na.action")
+  if(x) fit$x <- X
+  if(!y) fit$y <- NULL
+  fit$theta <- as.vector(th)
+  fit$SE.theta <- attr(th, "SE")
+  fit$twologlik <- as.vector(2 * Lm)
+  fit$aic <- -fit$twologlik + 2*fit$rank + 2
+  fit$contrasts <- attr(X, "contrasts")
+  fit$xlevels <- .getXlevels(Terms, mf)
+  fit$method <- method
+  fit$control <- control
+  fit$offset <- offset
+  fit
 }
 
 negative.binomial <-
-    function(theta = stop("'theta' must be specified"), link = "log")
-{
+  function(theta = stop("'theta' must be specified"), link = "log")
+  {
     linktemp <- substitute(link)
     if (!is.character(linktemp)) linktemp <- deparse(linktemp)
     if (linktemp %in% c("log", "identity", "sqrt"))
-        stats <- make.link(linktemp)
+      stats <- make.link(linktemp)
     else if (is.character(link)) {
-        stats <- make.link(link)
-        linktemp <- link
+      stats <- make.link(link)
+      linktemp <- link
     } else {
-        ## what else shall we allow?  At least objects of class link-glm.
-        if(inherits(link, "link-glm")) {
-            stats <- link
-            if(!is.null(stats$name)) linktemp <- stats$name
-        } else
-            stop(gettextf("\"%s\" link not available for negative binomial family; available links are \"identity\", \"log\" and \"sqrt\"", linktemp))
+      ## what else shall we allow?  At least objects of class link-glm.
+      if(inherits(link, "link-glm")) {
+        stats <- link
+        if(!is.null(stats$name)) linktemp <- stats$name
+      } else
+        stop(gettextf("\"%s\" link not available for negative binomial family; available links are \"identity\", \"log\" and \"sqrt\"", linktemp))
     }
     .Theta <- theta ## avoid codetools warnings
     env <- new.env(parent=.GlobalEnv)
     assign(".Theta", theta, envir=env)
     variance <- function(mu)
-        mu + mu^2/.Theta
+      mu + mu^2/.Theta
     validmu <- function(mu)
-        all(mu > 0)
+      all(mu > 0)
     dev.resids <- function(y, mu, wt)
-        2 * wt * (y * log(pmax(1, y)/mu) - (y + .Theta) *
+      2 * wt * (y * log(pmax(1, y)/mu) - (y + .Theta) *
                   log((y + .Theta)/ (mu + .Theta)))
     aic <- function(y, n, mu, wt, dev) {
-        term <- (y + .Theta) * log(mu + .Theta) - y * log(mu) +
-            lgamma(y + 1) - .Theta * log(.Theta) + lgamma(.Theta) - lgamma(.Theta+y)
-        2 * sum(term * wt)
+      term <- (y + .Theta) * log(mu + .Theta) - y * log(mu) +
+        lgamma(y + 1) - .Theta * log(.Theta) + lgamma(.Theta) - lgamma(.Theta+y)
+      2 * sum(term * wt)
     }
     initialize <- expression({
-        if (any(y < 0))
-            stop("negative values not allowed for the negative binomial family")
-        n <- rep(1, nobs)
-        mustart <- y + (y == 0)/6
+      if (any(y < 0))
+        stop("negative values not allowed for the negative binomial family")
+      n <- rep(1, nobs)
+      mustart <- y + (y == 0)/6
     })
     simfun <- function(object, nsim) {
-        ftd <- fitted(object)
-        rnegbin(nsim * length(ftd), ftd, .Theta)
+      ftd <- fitted(object)
+      rnegbin(nsim * length(ftd), ftd, .Theta)
     }
     environment(variance) <- environment(validmu) <-
-        environment(dev.resids) <- environment(aic) <-
-            environment(simfun) <- env
+      environment(dev.resids) <- environment(aic) <-
+      environment(simfun) <- env
     famname <- paste("Negative Binomial(", format(round(theta, 4)), ")",
                      sep = "")
     structure(list(family = famname, link = linktemp, linkfun = stats$linkfun,
@@ -264,44 +457,44 @@ negative.binomial <-
                    initialize = initialize, validmu = validmu,
                    valideta = stats$valideta, simulate = simfun),
               class = "family")
-}
+  }
 
 rnegbin <- function(n, mu = n, theta = stop("'theta' must be specified"))
 {
-    k <- if(length(n) > 1L) length(n) else n
-    rpois(k, (mu * rgamma(k, theta))/theta)
+  k <- if(length(n) > 1L) length(n) else n
+  rpois(k, (mu * rgamma(k, theta))/theta)
 }
 
 summary.negbin <- function(object, dispersion = 1, correlation = FALSE, ...)
 {
-    if(is.null(dispersion)) dispersion <- 1
-    summ <- c(summary.glm(object, dispersion = dispersion,
-                          correlation = correlation),
-              object[c("theta", "SE.theta", "twologlik", "th.warn")])
-    class(summ) <- c("summary.negbin", "summary.glm")
-    summ
+  if(is.null(dispersion)) dispersion <- 1
+  summ <- c(summary.glm(object, dispersion = dispersion,
+                        correlation = correlation),
+            object[c("theta", "SE.theta", "twologlik", "th.warn")])
+  class(summ) <- c("summary.negbin", "summary.glm")
+  summ
 }
 
 print.summary.negbin <- function(x, ...)
 {
-    NextMethod()
-    dp <- max(2 - floor(log10(x$SE.theta)), 0)
-    cat("\n              Theta: ", format(round(x$theta, dp), nsmall=dp),
-        "\n          Std. Err.: ", format(round(x$SE.theta, dp), nsmall=dp),
-        "\n")
-    if(!is.null(x$th.warn))
-        cat("Warning while fitting theta:", x$th.warn,"\n")
-    cat("\n 2 x log-likelihood: ", format(round(x$twologlik, 3), nsmall=dp), "\n")
-    invisible(x)
+  NextMethod()
+  dp <- max(2 - floor(log10(x$SE.theta)), 0)
+  cat("\n              Theta: ", format(round(x$theta, dp), nsmall=dp),
+      "\n          Std. Err.: ", format(round(x$SE.theta, dp), nsmall=dp),
+      "\n")
+  if(!is.null(x$th.warn))
+    cat("Warning while fitting theta:", x$th.warn,"\n")
+  cat("\n 2 x log-likelihood: ", format(round(x$twologlik, 3), nsmall=dp), "\n")
+  invisible(x)
 }
 
 theta.md <-
-    function(y, mu, dfr, weights, limit = 20, eps = .Machine$double.eps^0.25)
-{
+  function(y, mu, dfr, weights, limit = 20, eps = .Machine$double.eps^0.25)
+  {
     if(inherits(y, "lm")) {
-        mu <- y$fitted.values
-        dfr <- y$df.residual
-        y <- if(is.null(y$y)) mu + residuals(y) else y$y
+      mu <- y$fitted.values
+      dfr <- y$df.residual
+      y <- if(is.null(y$y)) mu + residuals(y) else y$y
     }
     if(missing(weights)) weights <- rep(1, length(y))
     n <- sum(weights)
@@ -310,35 +503,35 @@ theta.md <-
     it <- 0
     del <- 1
     while((it <- it + 1) < limit && abs(del) > eps) {
-        t0 <- abs(t0)
-        tmp <- log((y + t0)/(mu + t0))
-        top <- a - 2 * sum(weights*(y + t0) * tmp)
-        bot <- 2 * sum(weights*((y - mu)/(mu + t0) - tmp))
-        del <- top/bot
-        t0 <- t0 - del
+      t0 <- abs(t0)
+      tmp <- log((y + t0)/(mu + t0))
+      top <- a - 2 * sum(weights*(y + t0) * tmp)
+      bot <- 2 * sum(weights*((y - mu)/(mu + t0) - tmp))
+      del <- top/bot
+      t0 <- t0 - del
     }
     if(t0 < 0) {
-        t0 <- 0
-        warning("estimate truncated at zero")
-        attr(t0, "warn") <- gettext("estimate truncated at zero")
+      t0 <- 0
+      warning("estimate truncated at zero")
+      attr(t0, "warn") <- gettext("estimate truncated at zero")
     }
     t0
-}
+  }
 
 theta.ml <-
-    function(y, mu, n = sum(weights), weights, limit = 10,
-             eps = .Machine$double.eps^0.25,
-             trace = FALSE)
-{
+  function(y, mu, n = sum(weights), weights, limit = 10,
+           eps = .Machine$double.eps^0.25,
+           trace = FALSE)
+  {
     score <- function(n, th, mu, y, w)
-        sum(w*(digamma(th + y) - digamma(th) + log(th) +
+      sum(w*(digamma(th + y) - digamma(th) + log(th) +
                1 - log(th + mu) - (y + th)/(mu + th)))
     info <- function(n, th, mu, y, w)
-        sum(w*( - trigamma(th + y) + trigamma(th) - 1/th +
-               2/(mu + th) - (y + th)/(mu + th)^2))
+      sum(w*( - trigamma(th + y) + trigamma(th) - 1/th +
+                2/(mu + th) - (y + th)/(mu + th)^2))
     if(inherits(y, "lm")) {
-        mu <- y$fitted.values
-        y <- if(is.null(y$y)) mu + residuals(y) else y$y
+      mu <- y$fitted.values
+      y <- if(is.null(y$y)) mu + residuals(y) else y$y
     }
     if(missing(weights)) weights <- rep(1, length(y))
     t0 <- n/sum(weights*(y/mu - 1)^2)
@@ -347,95 +540,140 @@ theta.ml <-
     if(trace) message(sprintf("theta.ml: iter %d 'theta = %f'",
                               it, signif(t0)), domain = NA)
     while((it <- it + 1) < limit && abs(del) > eps) {
-        t0 <- abs(t0)
-		score_it <- score(n, t0, mu, y, weights)
-		info_it <- info(n, t0, mu, y, weights)
-		if(info_it != 0){
-          del <- score_it/info_it
-		  t0 <- t0 + del
-          if(trace) message("theta.ml: iter", it," theta =", signif(t0))
-		}else{
-		  print("Observed fisher information is equal to zero, stopped theta update.")	
-		  t0 <- .Machine$double.xmax
-		  info_it <- 0	
-		  break	
-		}	
+      t0 <- abs(t0)
+      del <- score(n, t0, mu, y, weights)/(i <- info(n, t0, mu, y, weights))
+      t0 <- t0 + del
+      if(trace) message("theta.ml: iter", it," theta =", signif(t0))
     }
     if(t0 < 0) {
-        t0 <- 0
-        warning("estimate truncated at zero")
-        attr(t0, "warn") <- gettext("estimate truncated at zero")
+      t0 <- 0
+      warning("estimate truncated at zero")
+      attr(t0, "warn") <- gettext("estimate truncated at zero")
     }
     if(it == limit) {
-        warning("iteration limit reached")
-        attr(t0, "warn") <- gettext("iteration limit reached")
+      warning("iteration limit reached")
+      attr(t0, "warn") <- gettext("iteration limit reached")
     }
-    attr(t0, "SE") <- ifelse(info_it != 0,sqrt(1/abs(i),"Undefined :: Poisson case")
+    attr(t0, "SE") <- sqrt(1/i)
     t0
-}
+  }
+
+## Newly added function. corrected theta.ml for the cases
+## where data behaves like poisson and theta grows to infinity
+## returns NA; this NA is then consumed by glm.nb2 function which
+## then applies poisson fallback
+theta.ml2 <-
+  function(y, mu, n = sum(weights), weights, limit = 10,
+           eps = .Machine$double.eps^0.25,
+           trace = FALSE)
+  {
+    score <- function(n, th, mu, y, w)
+      sum(w*(digamma(th + y) - digamma(th) + log(th) +
+               1 - log(th + mu) - (y + th)/(mu + th)))
+    info <- function(n, th, mu, y, w)
+      sum(w*( - trigamma(th + y) + trigamma(th) - 1/th +
+                2/(mu + th) - (y + th)/(mu + th)^2))
+    if(inherits(y, "lm")) {
+      mu <- y$fitted.values
+      y <- if(is.null(y$y)) mu + residuals(y) else y$y
+    }
+    if(missing(weights)) weights <- rep(1, length(y))
+    t0 <- n/sum(weights*(y/mu - 1)^2)
+    it <- 0
+    del <- 1
+    if(trace) message(sprintf("theta.ml: iter %d 'theta = %f'",
+                              it, signif(t0)), domain = NA)
+    while((it <- it + 1) < limit && abs(del) > eps) {
+      t0 <- abs(t0)
+      score_it <- score(n, t0, mu, y, weights)
+      info_it <- info(n, t0, mu, y, weights)
+      if(info_it != 0){
+        del <- score_it/info_it
+        t0 <- t0 + del
+        if(trace) message("theta.ml: iter", it," theta =", signif(t0))
+      }else{
+        warning("Observed fisher information is equal to zero, stopped theta update.")
+        cat(rep(".", 3), sep = "\n")
+        warning("Applying Poisson Fallback.")
+        return(NA)
+      }	
+    }
+    
+    if(t0 < 0) {
+      t0 <- 0
+      warning("estimate truncated at zero")
+      attr(t0, "warn") <- gettext("estimate truncated at zero")
+    }
+    if(it == limit) {
+      warning("iteration limit reached")
+      attr(t0, "warn") <- gettext("iteration limit reached")
+    }
+    attr(t0, "SE") <- sqrt(1/info_it)
+    return(t0)
+  }
 
 theta.mm <- function(y, mu, dfr, weights, limit = 10,
                      eps = .Machine$double.eps^0.25)
 {
-    if(inherits(y, "lm")) {
-        mu <- y$fitted.values
-        dfr <- y$df.residual
-        y <- if(is.null(y$y)) mu + residuals(y) else y$y
-    }
-    if(missing(weights)) weights <- rep(1, length(y))
-    n <- sum(weights)
-    t0 <- n/sum(weights*(y/mu - 1)^2)
-    it <- 0
-    del <- 1
-    while((it <- it + 1) < limit && abs(del) > eps) {
-        t0 <- abs(t0)
-        del <- (sum(weights*((y - mu)^2/(mu + mu^2/t0))) - dfr)/
-            sum(weights*(y - mu)^2/(mu + t0)^2)
-        t0 <- t0 - del
-    }
-    if(t0 < 0) {
-        t0 <- 0
-        warning("estimate truncated at zero")
-        attr(t0, "warn") <- gettext("estimate truncated at zero")
-    }
-    t0
+  if(inherits(y, "lm")) {
+    mu <- y$fitted.values
+    dfr <- y$df.residual
+    y <- if(is.null(y$y)) mu + residuals(y) else y$y
+  }
+  if(missing(weights)) weights <- rep(1, length(y))
+  n <- sum(weights)
+  t0 <- n/sum(weights*(y/mu - 1)^2)
+  it <- 0
+  del <- 1
+  while((it <- it + 1) < limit && abs(del) > eps) {
+    t0 <- abs(t0)
+    del <- (sum(weights*((y - mu)^2/(mu + mu^2/t0))) - dfr)/
+      sum(weights*(y - mu)^2/(mu + t0)^2)
+    t0 <- t0 - del
+  }
+  if(t0 < 0) {
+    t0 <- 0
+    warning("estimate truncated at zero")
+    attr(t0, "warn") <- gettext("estimate truncated at zero")
+  }
+  t0
 }
 
 logLik.negbin <- function(object, ...)
 {
-    if (nargs() > 1L) warning("extra arguments discarded")
-    p <- object$rank + 1L # for theta
-    val <- object$twologlik/2
-    attr(val, "df") <- p
-    attr(val, "nobs") <- sum(!is.na(object$residuals)) # as for glm
-    class(val) <- "logLik"
-    val
+  if (nargs() > 1L) warning("extra arguments discarded")
+  p <- object$rank + 1L # for theta
+  val <- object$twologlik/2
+  attr(val, "df") <- p
+  attr(val, "nobs") <- sum(!is.na(object$residuals)) # as for glm
+  class(val) <- "logLik"
+  val
 }
 
 vcov.negbin <- function(object, ...)
-    with(summary.negbin(object, ...), dispersion * cov.unscaled)
+  with(summary.negbin(object, ...), dispersion * cov.unscaled)
 
 ## based on simulate.lm
 simulate.negbin <- function(object, nsim = 1, seed = NULL, ...)
 {
-    if(!exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE))
-        runif(1)                     # initialize the RNG if necessary
-    if(is.null(seed))
-        RNGstate <- get(".Random.seed", envir = .GlobalEnv)
-    else {
-        R.seed <- get(".Random.seed", envir = .GlobalEnv)
-	set.seed(seed)
-        RNGstate <- structure(seed, kind = as.list(RNGkind()))
-        on.exit(assign(".Random.seed", R.seed, envir = .GlobalEnv))
-    }
-    ftd <- fitted(object)
-    nm <- names(ftd)
-    n <- length(ftd)
-    val <- rnegbin(n * nsim, ftd, object$theta)
-    dim(val) <- c(n, nsim)
-    val <- as.data.frame(val)
-    names(val) <- paste("sim", seq_len(nsim), sep="_")
-    if (!is.null(nm)) row.names(val) <- nm
-    attr(val, "seed") <- RNGstate
-    val
+  if(!exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE))
+    runif(1)                     # initialize the RNG if necessary
+  if(is.null(seed))
+    RNGstate <- get(".Random.seed", envir = .GlobalEnv)
+  else {
+    R.seed <- get(".Random.seed", envir = .GlobalEnv)
+    set.seed(seed)
+    RNGstate <- structure(seed, kind = as.list(RNGkind()))
+    on.exit(assign(".Random.seed", R.seed, envir = .GlobalEnv))
+  }
+  ftd <- fitted(object)
+  nm <- names(ftd)
+  n <- length(ftd)
+  val <- rnegbin(n * nsim, ftd, object$theta)
+  dim(val) <- c(n, nsim)
+  val <- as.data.frame(val)
+  names(val) <- paste("sim", seq_len(nsim), sep="_")
+  if (!is.null(nm)) row.names(val) <- nm
+  attr(val, "seed") <- RNGstate
+  val
 }

--- a/R/negbin.R
+++ b/R/negbin.R
@@ -348,9 +348,18 @@ theta.ml <-
                               it, signif(t0)), domain = NA)
     while((it <- it + 1) < limit && abs(del) > eps) {
         t0 <- abs(t0)
-        del <- score(n, t0, mu, y, weights)/(i <- info(n, t0, mu, y, weights))
-        t0 <- t0 + del
-        if(trace) message("theta.ml: iter", it," theta =", signif(t0))
+		score_it <- score(n, t0, mu, y, weights)
+		info_it <- info(n, t0, mu, y, weights)
+		if(info_it != 0){
+          del <- score_it/info_it
+		  t0 <- t0 + del
+          if(trace) message("theta.ml: iter", it," theta =", signif(t0))
+		}else{
+		  print("Observed fisher information is equal to zero, stopped theta update.")	
+		  t0 <- .Machine$double.xmax
+		  info_it <- 0	
+		  break	
+		}	
     }
     if(t0 < 0) {
         t0 <- 0
@@ -361,7 +370,7 @@ theta.ml <-
         warning("iteration limit reached")
         attr(t0, "warn") <- gettext("iteration limit reached")
     }
-    attr(t0, "SE") <- sqrt(1/i)
+    attr(t0, "SE") <- ifelse(info_it != 0,sqrt(1/abs(i),"Undefined :: Poisson case")
     t0
 }
 

--- a/R/negbin.R
+++ b/R/negbin.R
@@ -300,6 +300,7 @@ glm.nb2 <- function(formula, data, weights,
       fit$null.deviance <- null.deviance
     }
 
+    class(fit) <- c("pois", "glm", "lm")
     fit$terms <- Terms
     fit$formula <- as.vector(attr(Terms, "formula"))
     ## make result somewhat reproducible
@@ -309,8 +310,8 @@ glm.nb2 <- function(formula, data, weights,
     fit$na.action <- attr(mf, "na.action")
     if(x) fit$x <- X
     if(!y) fit$y <- NULL
-    fit$theta <- as.vector(th)
-    fit$SE.theta <- attr(th, "SE")
+    fit$theta <- Inf  
+    fit$SE.theta <- "Undefined"
     fit$twologlik <- as.vector(2 * Lm)
     fit$aic <- -fit$twologlik + 2*fit$rank + 2
     fit$contrasts <- attr(X, "contrasts")

--- a/R/negbin.R
+++ b/R/negbin.R
@@ -300,7 +300,7 @@ glm.nb2 <- function(formula, data, weights,
       fit$null.deviance <- null.deviance
     }
 
-    class(fit) <- c("pois", "glm", "lm")
+    #class(fit) <- c("pois", "glm", "lm")
     fit$terms <- Terms
     fit$formula <- as.vector(attr(Terms, "formula"))
     ## make result somewhat reproducible

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+1. Fixed glm.nb() behavior for data that are effectively Poisson: when the dispersion parameter (theta) diverges, the routine now triggers a Poisson fallback implemented via theta.ml2.
+
+2. Updated theta.ml() so that when estimation indicates a Poisson-like degenerate case (theta → ∞), it returns NA. The glm.nb2() wrapper consumes this NA and applies the Poisson fallback, preventing numeric errors and misleading non-convergence messages.


### PR DESCRIPTION
Hi all,

I am writing to report an issue I encountered while using the glm.nb() function from the MASS package in R.

I generated a sample from a Negative Binomial distribution with fixed mu and size, and then attempted to fit a Negative Binomial model using glm.nb() with maxit = 500 (to allow for thorough estimation). However, the function returns the following error:

**Error in while ((it <- it + 1) < limit && abs(del) > eps) { :
  missing value where TRUE/FALSE needed**
  
After a step-by-step investigation, the origin of the issue appears to be the internal function [theta.ml](http://theta.ml/)(). In my case, the randomly generated data by “bad luck” happens to behave very much like Poisson data. As a result:

1. The MLE of the dispersion parameter theta theoretically tends to infinity.

2. [theta.ml](http://theta.ml/)() keeps increasing theta at each iteration.

3. At large values of theta, both the score function (first derivative of the log-likelihood) and the information function (negative second derivative) become numerically zero.

4. This results in del = score / info becoming 0/0 or the denominator becoming exactly zero.

5. That unhandled NaN leads to the error above during the Newton-Raphson update (see the image attached below).

<img width="652" height="388" alt="image" src="https://github.com/user-attachments/assets/551a4a3f-80d2-4615-9570-f4acd7a8b54c" />

For Poisson-like data, the correct theoretical solution is indeed theta = ∞, but the current implementation does not gracefully handle the case where info = 0 or score = info = 0 . This can mislead users who are unfamiliar with the estimation mechanism by presenting it as a convergence failure instead of the model behaving as Poisson.

It would be helpful to implement a safeguard for this scenario - for example, detecting degeneracy in the score or information function and returning a large finite theta (or a Poisson model) instead of an error.

I’m happy to assist in testing or providing more details if needed.